### PR TITLE
refactor: Simplify auth to use Azure EasyAuth headers directly

### DIFF
--- a/backend/TESTING-AUTH-MIDDLEWARE.md
+++ b/backend/TESTING-AUTH-MIDDLEWARE.md
@@ -1,10 +1,19 @@
 # Testing EasyAuth Middleware
 
-This guide provides step-by-step instructions to manually test the EasyAuth authentication middleware.
+Guide for testing the Azure EasyAuth authentication middleware.
+
+## Overview
+
+The middleware uses Azure EasyAuth headers (set automatically by Azure for valid tokens):
+- `x-ms-client-principal-id` - User ID from OAuth provider
+- `x-ms-client-principal-name` - Email address
+- `x-ms-client-principal-idp` - Identity provider (google/facebook)
+
+No custom token validation - Azure handles all validation.
 
 ## Prerequisites
 
-1. Install dependencies (from project root):
+1. Install dependencies:
    ```bash
    pnpm install
    ```
@@ -22,11 +31,9 @@ This guide provides step-by-step instructions to manually test the EasyAuth auth
 
 ## Test Cases
 
-### Test 1: Development Mode Bypass (No Header)
+### Test 1: Development Mode Bypass
 
-**Description**: In development mode, requests without auth header should work with mock user.
-
-**Setup**: Ensure `NODE_ENV=development` in `.env`
+**Description**: In development mode, requests without auth headers use mock user.
 
 **Request**:
 ```bash
@@ -48,37 +55,18 @@ curl http://localhost:3000/api/v1/test/me
 }
 ```
 
-**Verification**:
-- ✅ Status code is 200
-- ✅ Response contains mock user data
-- ✅ userId is "dev-user-123"
-- ✅ Server logs show "Development mode: Using mock user"
-
 ---
 
-### Test 2: Valid EasyAuth Header
+### Test 2: Valid EasyAuth Headers
 
-**Description**: Valid Base64-encoded EasyAuth header should authenticate successfully.
-
-**Setup**: Create a valid header (Base64-encoded JSON)
-
-**Create Test Header**:
-```javascript
-// Node.js command to generate test header
-const claims = {
-  userId: "google|123456789",
-  userDetails: "test@example.com",
-  identityProvider: "google",
-  auth_typ: "aad"
-};
-const header = Buffer.from(JSON.stringify(claims)).toString('base64');
-console.log(header);
-```
+**Description**: Valid EasyAuth headers authenticate successfully.
 
 **Request**:
 ```bash
 curl http://localhost:3000/api/v1/test/me \
-  -H "x-ms-client-principal: eyJ1c2VySWQiOiJnb29nbGV8MTIzNDU2Nzg5IiwidXNlckRldGFpbHMiOiJ0ZXN0QGV4YW1wbGUuY29tIiwiaWRlbnRpdHlQcm92aWRlciI6Imdvb2dsZSIsImF1dGhfdHlwIjoiYWFkIn0="
+  -H "x-ms-client-principal-id: google|123456789" \
+  -H "x-ms-client-principal-name: test@example.com" \
+  -H "x-ms-client-principal-idp: google"
 ```
 
 **Expected Response** (200 OK):
@@ -96,27 +84,16 @@ curl http://localhost:3000/api/v1/test/me \
 }
 ```
 
-**Verification**:
-- ✅ Status code is 200
-- ✅ userId matches header claims
-- ✅ email matches header claims
-- ✅ provider is "google"
-- ✅ Server logs show "User authenticated successfully"
-
 ---
 
 ### Test 3: Missing Header (Production Mode)
 
-**Description**: In production mode, missing auth header should return 401.
-
-**Setup**: Set `NODE_ENV=production` in `.env` or override:
+**Description**: In production mode, missing auth headers return 401.
 
 **Request**:
 ```bash
 NODE_ENV=production curl http://localhost:3000/api/v1/test/me
 ```
-
-Or temporarily modify the middleware to skip development bypass.
 
 **Expected Response** (401 Unauthorized):
 ```json
@@ -129,86 +106,37 @@ Or temporarily modify the middleware to skip development bypass.
 }
 ```
 
-**Verification**:
-- ✅ Status code is 401
-- ✅ Error message is clear
-- ✅ Server logs show "Authentication failed: Missing x-ms-client-principal header"
-
 ---
 
-### Test 4: Invalid/Malformed Header
+### Test 4: Partial Headers
 
-**Description**: Invalid Base64 or malformed JSON should return 401.
+**Description**: Only `x-ms-client-principal-id` is required.
 
-**Test 4a: Invalid Base64**
-
-**Request**:
+**Request** (minimal):
 ```bash
 curl http://localhost:3000/api/v1/test/me \
-  -H "x-ms-client-principal: not-valid-base64!!!"
+  -H "x-ms-client-principal-id: user123"
 ```
 
-**Expected Response** (401 Unauthorized):
+**Expected Response** (200 OK):
 ```json
 {
-  "error": {
-    "message": "Invalid authentication token",
-    "code": "INVALID_TOKEN"
+  "data": {
+    "message": "Authentication successful",
+    "user": {
+      "userId": "user123",
+      "provider": "google"
+    }
   },
-  "success": false
+  "success": true
 }
 ```
-
-**Test 4b: Valid Base64 but Invalid JSON**
-
-**Request**:
-```bash
-curl http://localhost:3000/api/v1/test/me \
-  -H "x-ms-client-principal: $(echo -n 'not json' | base64)"
-```
-
-**Expected Response** (401 Unauthorized):
-```json
-{
-  "error": {
-    "message": "Invalid authentication token",
-    "code": "INVALID_TOKEN"
-  },
-  "success": false
-}
-```
-
-**Test 4c: Valid JSON but Missing Required Fields**
-
-**Request**:
-```bash
-# Missing userId
-CLAIMS='{"userDetails":"test@example.com","identityProvider":"google"}'
-HEADER=$(echo -n $CLAIMS | base64)
-curl http://localhost:3000/api/v1/test/me -H "x-ms-client-principal: $HEADER"
-```
-
-**Expected Response** (401 Unauthorized):
-```json
-{
-  "error": {
-    "message": "Invalid authentication token",
-    "code": "INVALID_TOKEN"
-  },
-  "success": false
-}
-```
-
-**Verification**:
-- ✅ All malformed cases return 401
-- ✅ Error code is "INVALID_TOKEN"
-- ✅ Server logs show "Authentication failed: Error decoding" or "Invalid EasyAuth claims structure"
 
 ---
 
 ### Test 5: Public Route (Health Check)
 
-**Description**: Public routes should work without authentication.
+**Description**: Public routes work without authentication.
 
 **Request**:
 ```bash
@@ -228,111 +156,23 @@ curl http://localhost:3000/api/v1/health
 }
 ```
 
-**Verification**:
-- ✅ Health endpoint works without auth header
-- ✅ Status code is 200
-
----
-
-## TypeScript Type Checking
-
-Verify that TypeScript recognizes the extended Request type:
-
-**Test File**: Create a temporary test file
-```typescript
-// backend/src/test-types.ts
-import { Request, Response } from 'express';
-import { validateAuth } from './middleware/auth';
-
-// This should compile without errors
-function testHandler(req: Request, res: Response) {
-  // After validateAuth middleware, req.user should be available
-  if (req.user) {
-    const userId: string = req.user.userId;
-    const email: string | undefined = req.user.email;
-    const provider: 'google' | 'facebook' = req.user.provider;
-
-    console.log({ userId, email, provider });
-  }
-}
-```
-
-**Run Type Check**:
-```bash
-pnpm --filter backend type-check
-```
-
-**Expected**: No TypeScript errors
-
----
-
-## Integration with Future Routes
-
-When creating protected routes (users, snapshots, import), apply middleware like this:
-
-```typescript
-// Example: backend/src/routes/userRoutes.ts
-import { Router } from 'express';
-import { validateAuth } from '../middleware/auth';
-
-const router = Router();
-
-// All routes in this module will require authentication
-// because validateAuth is applied at the route level in index.ts
-
-router.get('/me', (req, res) => {
-  const userId = req.user!.userId; // Safe to use non-null assertion
-  // ... fetch user from database
-});
-
-export default router;
-```
-
-```typescript
-// backend/src/routes/index.ts
-import userRoutes from './userRoutes';
-import { validateAuth } from '../middleware/auth';
-
-// Apply auth middleware to entire route module
-router.use('/users', validateAuth, userRoutes);
-```
-
 ---
 
 ## Checklist
 
-Use this checklist to verify all acceptance criteria:
-
-- [ ] Middleware function `validateAuth` created
-- [ ] Extracts and decodes `x-ms-client-principal` header
-- [ ] Parses JSON to extract userId, email, identityProvider
-- [ ] Attaches `req.user` object with typed interface
-- [ ] Returns 401 if header missing on protected routes
-- [ ] Returns 401 if header malformed or invalid
-- [ ] Supports development mode bypass (mock user)
-- [ ] TypeScript types extended for Express Request
-- [ ] Test endpoint `/api/v1/test/me` works
-- [ ] Server logs authentication events
+- [x] Middleware reads `x-ms-client-principal-id` header
+- [x] Middleware reads `x-ms-client-principal-name` header (optional)
+- [x] Middleware reads `x-ms-client-principal-idp` header (optional)
+- [x] Returns 401 if `x-ms-client-principal-id` missing (production mode)
+- [x] Development mode bypass with mock user
+- [x] TypeScript types for Express Request.user
 
 ---
 
 ## Troubleshooting
 
-**Issue**: TypeScript doesn't recognize `req.user`
-**Solution**: Ensure `typeRoots` is set in `tsconfig.json` and includes `./src/types`
-
 **Issue**: Development bypass not working
 **Solution**: Verify `NODE_ENV=development` in `.env` file
 
-**Issue**: Header decoding fails
-**Solution**: Ensure header is properly Base64-encoded. Use `btoa(JSON.stringify(claims))` in browser or `Buffer.from(...).toString('base64')` in Node.js
-
----
-
-## Next Steps
-
-After verifying all test cases:
-1. Mark all acceptance criteria as complete
-2. Update task progress log
-3. Move task to `.task-board/done/`
-4. Proceed to next task: `006-FEATURE-user-api-endpoints.md`
+**Issue**: Getting 401 in production
+**Solution**: Ensure Azure EasyAuth is properly configured on the App Service

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,8 +37,13 @@ function createApp(): Application {
       }
     },
     credentials: true,
-    // Allow custom auth header from frontend
-    allowedHeaders: ['Content-Type', 'X-MS-CLIENT-PRINCIPAL'],
+    // Allow EasyAuth headers from Azure
+    allowedHeaders: [
+      'Content-Type',
+      'X-MS-CLIENT-PRINCIPAL-ID',
+      'X-MS-CLIENT-PRINCIPAL-NAME',
+      'X-MS-CLIENT-PRINCIPAL-IDP'
+    ],
   }));
 
   // Body parser middleware

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,229 +1,39 @@
 /**
- * EasyAuth Authentication Middleware
+ * Azure EasyAuth Authentication Middleware
  *
- * Validates Azure EasyAuth headers and extracts user information.
- * Protected routes require valid authentication or return 401 Unauthorized.
+ * Uses Azure EasyAuth headers set automatically when a valid token is sent:
+ * - x-ms-client-principal-id: User ID from OAuth provider
+ * - x-ms-client-principal-name: Email address
+ * - x-ms-client-principal-idp: Identity provider (google/facebook)
  *
- * Supports two authentication methods:
- * 1. Authorization: Bearer <token> - OAuth access_token validated against provider
- * 2. X-MS-CLIENT-PRINCIPAL - Base64-encoded user claims (backward compat)
+ * No custom token validation - Azure EasyAuth handles all validation.
  */
 
 import { Request, Response, NextFunction } from 'express';
-import axios from 'axios';
 import { logger } from '../utils/logger';
 
 /**
- * EasyAuth user claims structure from x-ms-client-principal header
- * Header contains Base64-encoded JSON with user information
- */
-interface EasyAuthClaims {
-  auth_typ?: string;
-  claims?: Array<{ typ: string; val: string }>;
-  name_typ?: string;
-  role_typ?: string;
-  userId: string;
-  userDetails?: string; // email address
-  identityProvider: string;
-}
-
-/**
- * Google tokeninfo response for id_token validation
- * When validating id_token, Google returns the JWT claims
- */
-interface GoogleTokenInfo {
-  // Standard JWT claims
-  iss: string;           // Issuer (https://accounts.google.com)
-  sub: string;           // Subject (Google user ID)
-  aud: string;           // Audience (your client ID)
-  exp: string;           // Expiration timestamp
-  iat: string;           // Issued at timestamp
-  // User claims
-  email: string;
-  email_verified: string;
-  name?: string;
-  picture?: string;
-  given_name?: string;
-  family_name?: string;
-  // Error field (only if invalid)
-  error_description?: string;
-}
-
-/**
- * Facebook user response
- */
-interface FacebookUserInfo {
-  id: string;
-  email?: string;
-  error?: { message: string };
-}
-
-/**
- * Authenticated user info extracted from OAuth token
- */
-interface AuthUser {
-  userId: string;
-  email?: string;
-  provider: 'google' | 'facebook';
-}
-
-/**
- * Cache for validated tokens to reduce OAuth provider calls
- */
-const tokenCache = new Map<string, { user: AuthUser; expiry: number }>();
-const TOKEN_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-
-/**
- * Validates Google OAuth id_token (JWT)
- * Uses Google's tokeninfo endpoint to validate the JWT signature and claims
- */
-async function validateGoogleToken(token: string): Promise<AuthUser | null> {
-  try {
-    // Google's tokeninfo endpoint validates id_tokens
-    // Use id_token param for JWT tokens (not access_token)
-    logger.info('Calling Google tokeninfo API...');
-    const response = await axios.get<GoogleTokenInfo>(
-      `https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(token)}`,
-      { timeout: 5000 }
-    );
-
-    if (response.data.error_description) {
-      logger.warn('Google id_token validation failed', { error: response.data.error_description });
-      return null;
-    }
-
-    if (!response.data.email || !response.data.sub) {
-      logger.warn('Google id_token missing required fields', {
-        hasEmail: !!response.data.email,
-        hasSub: !!response.data.sub
-      });
-      return null;
-    }
-
-    // Verify issuer is Google
-    if (response.data.iss !== 'https://accounts.google.com') {
-      logger.warn('Google id_token has invalid issuer', { iss: response.data.iss });
-      return null;
-    }
-
-    logger.info('Google token validated successfully', { sub: response.data.sub });
-    return {
-      userId: response.data.sub,
-      email: response.data.email,
-      provider: 'google'
-    };
-  } catch (error: unknown) {
-    const axiosError = error as { response?: { status?: number; data?: unknown } };
-    logger.warn('Google id_token validation error', {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: axiosError.response?.status,
-      data: axiosError.response?.data
-    });
-    return null;
-  }
-}
-
-/**
- * Validates Facebook OAuth access_token
- */
-async function validateFacebookToken(token: string): Promise<AuthUser | null> {
-  try {
-    const response = await axios.get<FacebookUserInfo>(
-      `https://graph.facebook.com/me?access_token=${encodeURIComponent(token)}&fields=id,email`,
-      { timeout: 5000 }
-    );
-
-    if (response.data.error) {
-      logger.debug('Facebook token validation failed', { error: response.data.error.message });
-      return null;
-    }
-
-    if (!response.data.id) {
-      logger.debug('Facebook token missing required fields');
-      return null;
-    }
-
-    return {
-      userId: response.data.id,
-      email: response.data.email,
-      provider: 'facebook'
-    };
-  } catch (error) {
-    logger.debug('Facebook token validation error', {
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
-    return null;
-  }
-}
-
-/**
- * Validates Bearer token (id_token JWT) against OAuth providers
- * Tries Google first (JWT id_token), then Facebook (access_token)
- */
-async function validateBearerToken(token: string): Promise<AuthUser | null> {
-  // Check cache first
-  const cached = tokenCache.get(token);
-  if (cached && cached.expiry > Date.now()) {
-    logger.debug('Using cached token validation');
-    return cached.user;
-  }
-
-  // Try Google first - expects id_token (JWT starting with eyJ)
-  if (token.startsWith('eyJ')) {
-    const user = await validateGoogleToken(token);
-    if (user) {
-      tokenCache.set(token, { user, expiry: Date.now() + TOKEN_CACHE_TTL });
-      return user;
-    }
-  }
-
-  // Try Facebook - uses access_token directly
-  const user = await validateFacebookToken(token);
-  if (user) {
-    tokenCache.set(token, { user, expiry: Date.now() + TOKEN_CACHE_TTL });
-    return user;
-  }
-
-  return null;
-}
-
-/**
- * Validates authentication via Bearer token or EasyAuth header
+ * Validates authentication via Azure EasyAuth headers
  *
- * Priority:
- * 1. Authorization: Bearer <token> - validated against OAuth provider
- * 2. X-MS-CLIENT-PRINCIPAL - decoded and validated locally
+ * Simply checks if x-ms-client-principal-id header exists.
+ * Azure EasyAuth sets this header only for valid, authenticated requests.
  *
  * @param req - Express request object
  * @param res - Express response object
  * @param next - Express next function
- * @returns 401 if authentication missing or invalid, otherwise calls next()
- *
- * @example
- * // Apply to protected routes
- * router.use('/users', validateAuth, userRoutes);
- *
- * // Access user in controller
- * const userId = req.user!.userId;
+ * @returns 401 if not authenticated, otherwise calls next()
  */
 export async function validateAuth(
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {
-  const authHeader = req.headers['authorization'] as string | undefined;
-  const principalHeader = req.headers['x-ms-client-principal'] as string | undefined;
-
-  // Log received auth headers for debugging
-  logger.info('Auth headers received', {
-    path: req.path,
-    hasBearer: !!authHeader?.startsWith('Bearer '),
-    hasPrincipal: !!principalHeader,
-    bearerPrefix: authHeader ? authHeader.substring(0, 30) + '...' : 'none'
-  });
+  const principalId = req.headers['x-ms-client-principal-id'] as string | undefined;
+  const principalName = req.headers['x-ms-client-principal-name'] as string | undefined;
+  const principalIdp = req.headers['x-ms-client-principal-idp'] as string | undefined;
 
   // Development bypass - inject mock user if no auth headers
-  if (process.env.NODE_ENV === 'development' && !authHeader && !principalHeader) {
+  if (process.env.NODE_ENV === 'development' && !principalId) {
     logger.debug('Development mode: Using mock user (no auth headers)');
     req.user = {
       userId: 'dev-user-123',
@@ -233,117 +43,34 @@ export async function validateAuth(
     return next();
   }
 
-  // Try Bearer token first (preferred method)
-  if (authHeader?.startsWith('Bearer ')) {
-    const token = authHeader.slice(7);
-
-    if (!token) {
-      logger.warn('Authentication failed: Empty Bearer token', {
-        path: req.path,
-        method: req.method
-      });
-      res.status(401).json({
-        error: {
-          message: 'Invalid authentication token',
-          code: 'INVALID_TOKEN'
-        },
-        success: false
-      });
-      return;
-    }
-
-    logger.info('Validating Bearer token against OAuth provider...');
-    const user = await validateBearerToken(token);
-    if (user) {
-      req.user = user;
-      logger.info('User authenticated via Bearer token', {
-        userId: user.userId,
-        provider: user.provider,
-        path: req.path
-      });
-      return next();
-    }
-
-    // Bearer token was provided but invalid - log details
-    logger.warn('Authentication failed: Bearer token validation failed', {
+  // Check for EasyAuth header
+  if (!principalId) {
+    logger.warn('Authentication failed: No x-ms-client-principal-id header', {
       path: req.path,
-      method: req.method,
-      tokenIsJWT: token.startsWith('eyJ'),
-      tokenLength: token.length
+      method: req.method
     });
     res.status(401).json({
       error: {
-        message: 'Invalid authentication token',
-        code: 'INVALID_TOKEN'
+        message: 'Authentication required',
+        code: 'UNAUTHORIZED'
       },
       success: false
     });
     return;
   }
 
-  // Fall back to X-MS-CLIENT-PRINCIPAL (backward compatibility)
-  if (principalHeader) {
-    try {
-      const decoded = Buffer.from(principalHeader, 'base64').toString('utf-8');
-      const claims: EasyAuthClaims = JSON.parse(decoded);
+  // Extract user from EasyAuth headers
+  req.user = {
+    userId: principalId,
+    email: principalName,
+    provider: (principalIdp as 'google' | 'facebook') || 'google'
+  };
 
-      if (!claims.userId || !claims.identityProvider) {
-        logger.error('Authentication failed: Invalid EasyAuth claims structure', {
-          hasUserId: !!claims.userId,
-          hasProvider: !!claims.identityProvider,
-          path: req.path
-        });
-        res.status(401).json({
-          error: {
-            message: 'Invalid authentication token',
-            code: 'INVALID_TOKEN'
-          },
-          success: false
-        });
-        return;
-      }
-
-      req.user = {
-        userId: claims.userId,
-        email: claims.userDetails,
-        provider: claims.identityProvider as 'google' | 'facebook'
-      };
-
-      logger.debug('User authenticated via X-MS-CLIENT-PRINCIPAL', {
-        userId: req.user.userId,
-        provider: req.user.provider,
-        path: req.path
-      });
-
-      return next();
-    } catch (error) {
-      logger.error('Authentication failed: Error decoding x-ms-client-principal', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        path: req.path,
-        method: req.method
-      });
-      res.status(401).json({
-        error: {
-          message: 'Invalid authentication token',
-          code: 'INVALID_TOKEN'
-        },
-        success: false
-      });
-      return;
-    }
-  }
-
-  // No authentication provided
-  logger.warn('Authentication failed: No authentication provided', {
-    path: req.path,
-    method: req.method,
-    ip: req.ip
+  logger.debug('User authenticated via EasyAuth', {
+    userId: req.user.userId,
+    provider: req.user.provider,
+    path: req.path
   });
-  res.status(401).json({
-    error: {
-      message: 'Authentication required',
-      code: 'UNAUTHORIZED'
-    },
-    success: false
-  });
+
+  return next();
 }


### PR DESCRIPTION
Remove all custom OAuth token validation (Google/Facebook API calls). Use Azure EasyAuth headers set automatically for valid tokens:
- x-ms-client-principal-id (user ID)
- x-ms-client-principal-name (email)
- x-ms-client-principal-idp (provider)

Middleware reduced from 350 to 77 lines.