### PR TITLE
Fix authentication issue with user endpoint

### DIFF
--- a/frontend/src/shared/api/authToken.ts
+++ b/frontend/src/shared/api/authToken.ts
@@ -166,8 +166,13 @@ async function fetchAuthToken(): Promise<CachedAuthData | null> {
     }
 
     // Cache all tokens
+    // Strip "Bearer " prefix if present (EasyAuth may return it with prefix)
+    const rawIdToken = identity.id_token.startsWith('Bearer ')
+      ? identity.id_token.slice(7)
+      : identity.id_token;
+
     cachedAuthData = {
-      idToken: identity.id_token,           // JWT for Bearer auth
+      idToken: rawIdToken,                  // JWT for Bearer auth (without prefix)
       accessToken: identity.access_token,   // Opaque token for Google API calls
       clientPrincipal: btoa(JSON.stringify(principal)),
       expiry,


### PR DESCRIPTION
EasyAuth was returning id_token with "Bearer " prefix already included. When frontend added "Bearer " again, the header became "Authorization: Bearer Bearer <token>" causing backend 401 errors.