### PR TITLE
Implement post-login onboarding flow

### DIFF
--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import client from '../../shared/api/client';
-import { clearAuthToken } from '../../shared/api/authToken';
+import { clearAuthToken, getAuthData } from '../../shared/api/authToken';
 import type { User, AuthContextType } from './types';
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -13,30 +13,57 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<User | null>(null);
+  const [hasEasyAuthSession, setHasEasyAuthSession] = useState(false);
+  const [needsOnboarding, setNeedsOnboarding] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const fetchUser = useCallback(async () => {
     try {
+      // First check if we have an EasyAuth session
+      let hasSession = false;
+      if (isDevelopment) {
+        // In development, always assume session exists (backend will inject dev user)
+        hasSession = true;
+      } else {
+        const authData = await getAuthData();
+        hasSession = authData !== null;
+      }
+      setHasEasyAuthSession(hasSession);
+
+      if (!hasSession) {
+        // No EasyAuth session - user needs to log in
+        setUser(null);
+        setNeedsOnboarding(false);
+        return;
+      }
+
+      // We have an EasyAuth session - check if user exists in our DB
       const response = await client.get('/users/me');
 
       if (response.data.success && response.data.data) {
         setUser(response.data.data);
+        setNeedsOnboarding(false);
       } else {
         setUser(null);
+        setNeedsOnboarding(true);
       }
     } catch (error: any) {
       // Handle different error cases
-      if (error.response?.status === 404) {
+      if (error.statusCode === 404) {
         // User authenticated via EasyAuth but not in our database
         // This means they need to complete onboarding
         setUser(null);
-      } else if (error.response?.status === 401) {
+        setNeedsOnboarding(true);
+      } else if (error.statusCode === 401) {
         // Not authenticated at all
         setUser(null);
+        setHasEasyAuthSession(false);
+        setNeedsOnboarding(false);
       } else {
-        // Network or other error
+        // Network or other error - preserve current state
         console.error('Error fetching user:', error);
         setUser(null);
+        setNeedsOnboarding(false);
       }
     } finally {
       setIsLoading(false);
@@ -51,7 +78,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     await fetchUser();
   }, [fetchUser]);
 
-  const login = async (provider: 'google' | 'facebook', returnUrl = '/dashboard') => {
+  const login = async (provider: 'google' | 'facebook', returnUrl = '/auth/callback') => {
     if (isDevelopment) {
       // In development, backend auto-injects dev user - just fetch and redirect
       await fetchUser();
@@ -65,6 +92,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Clear cached auth token
     clearAuthToken();
     setUser(null);
+    setHasEasyAuthSession(false);
+    setNeedsOnboarding(false);
 
     if (isDevelopment) {
       window.location.href = '/';
@@ -77,6 +106,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     user,
     isLoading,
     isAuthenticated: user !== null,
+    hasEasyAuthSession,
+    needsOnboarding,
     login,
     logout,
     refreshUser,

--- a/frontend/src/features/auth/LoginModal.tsx
+++ b/frontend/src/features/auth/LoginModal.tsx
@@ -14,7 +14,7 @@ interface LoginModalProps {
   returnUrl?: string;
 }
 
-export function LoginModal({ isOpen, onClose, returnUrl = '/dashboard' }: LoginModalProps) {
+export function LoginModal({ isOpen, onClose, returnUrl = '/auth/callback' }: LoginModalProps) {
   // Handle escape key to close modal
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,30 +1,30 @@
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { useAuth } from './useAuth';
 import './LoginPage.css';
 
-interface LocationState {
-  from?: string;
-}
-
 export default function LoginPage() {
-  const { isAuthenticated, isLoading } = useAuth();
-  const location = useLocation();
-  const state = location.state as LocationState | null;
+  const { isAuthenticated, isLoading, needsOnboarding } = useAuth();
 
-  // Get the return URL from state, default to /dashboard
-  const returnUrl = state?.from || '/dashboard';
-
-  // Redirect authenticated users to their intended destination
+  // Redirect authenticated users to dashboard
   if (!isLoading && isAuthenticated) {
-    return <Navigate to={returnUrl} replace />;
+    return <Navigate to="/dashboard" replace />;
   }
 
+  // Redirect users who need onboarding
+  if (!isLoading && needsOnboarding) {
+    return <Navigate to="/onboarding" replace />;
+  }
+
+  // Always redirect to /auth/callback after OAuth
+  // PostLoginPage will handle routing to onboarding or dashboard
+  const callbackUrl = '/auth/callback';
+
   const handleGoogleLogin = () => {
-    window.location.href = `/.auth/login/google?post_login_redirect_uri=${encodeURIComponent(returnUrl)}`;
+    window.location.href = `/.auth/login/google?post_login_redirect_uri=${encodeURIComponent(callbackUrl)}`;
   };
 
   const handleFacebookLogin = () => {
-    window.location.href = `/.auth/login/facebook?post_login_redirect_uri=${encodeURIComponent(returnUrl)}`;
+    window.location.href = `/.auth/login/facebook?post_login_redirect_uri=${encodeURIComponent(callbackUrl)}`;
   };
 
   return (

--- a/frontend/src/features/auth/OnboardingRoute.tsx
+++ b/frontend/src/features/auth/OnboardingRoute.tsx
@@ -1,0 +1,41 @@
+/**
+ * OnboardingRoute
+ *
+ * Route guard that only allows access to users who:
+ * - Have an EasyAuth session (hasEasyAuthSession = true)
+ * - Need to complete onboarding (needsOnboarding = true)
+ *
+ * Redirects to:
+ * - /dashboard if already authenticated
+ * - / (homepage) if no EasyAuth session
+ */
+
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './useAuth';
+import { LoadingSpinner } from '../../shared/components';
+
+interface OnboardingRouteProps {
+  children: React.ReactNode;
+}
+
+export default function OnboardingRoute({ children }: OnboardingRouteProps) {
+  const { isLoading, isAuthenticated, needsOnboarding } = useAuth();
+
+  if (isLoading) {
+    return <LoadingSpinner text="Laster..." />;
+  }
+
+  if (isAuthenticated) {
+    // User already completed onboarding - go to dashboard
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (!needsOnboarding) {
+    // No EasyAuth session - go to homepage to log in
+    return <Navigate to="/" replace />;
+  }
+
+  // User has EasyAuth session but needs onboarding
+  return <>{children}</>;
+}

--- a/frontend/src/features/auth/PostLoginPage.tsx
+++ b/frontend/src/features/auth/PostLoginPage.tsx
@@ -1,0 +1,35 @@
+/**
+ * PostLoginPage
+ *
+ * Landing page after OAuth redirect. Routes user to:
+ * - /onboarding if authenticated but not in our DB
+ * - /dashboard if authenticated and in our DB
+ * - / (homepage) if not authenticated
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from './useAuth';
+import { LoadingSpinner } from '../../shared/components';
+
+export default function PostLoginPage() {
+  const { isLoading, isAuthenticated, needsOnboarding } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (needsOnboarding) {
+      // User has EasyAuth session but not in our DB
+      navigate('/onboarding', { replace: true });
+    } else if (isAuthenticated) {
+      // User is fully authenticated
+      navigate('/dashboard', { replace: true });
+    } else {
+      // No session at all - back to homepage
+      navigate('/', { replace: true });
+    }
+  }, [isLoading, isAuthenticated, needsOnboarding, navigate]);
+
+  return <LoadingSpinner text="Logger inn..." />;
+}

--- a/frontend/src/features/auth/ProtectedRoute.tsx
+++ b/frontend/src/features/auth/ProtectedRoute.tsx
@@ -8,15 +8,20 @@ interface ProtectedRouteProps {
 }
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, needsOnboarding } = useAuth();
   const location = useLocation();
 
   if (isLoading) {
     return <LoadingSpinner text="Laster..." />;
   }
 
+  if (needsOnboarding) {
+    // User has EasyAuth session but hasn't completed onboarding
+    return <Navigate to="/onboarding" replace />;
+  }
+
   if (!isAuthenticated) {
-    // Redirect to home page where user can use login modal
+    // No session - redirect to home page where user can use login modal
     return <Navigate to="/" state={{ from: location.pathname }} replace />;
   }
 

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -37,6 +37,8 @@ export interface AuthContextType {
   user: User | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  hasEasyAuthSession: boolean;
+  needsOnboarding: boolean;
   login: (provider: 'google' | 'facebook', returnUrl?: string) => void;
   logout: () => void;
   refreshUser: () => Promise<void>;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from '../shared/components/Layout';
 import { LoadingSpinner } from '../shared/components';
 import ProtectedRoute from '../features/auth/ProtectedRoute';
+import OnboardingRoute from '../features/auth/OnboardingRoute';
 
 // Lazy load page components for code splitting
 const HomePage = lazy(() => import('../features/dashboard/HomePage'));
@@ -17,6 +18,7 @@ const FireCalculatorPage = lazy(() => import('../features/calculators/FireCalcul
 const LoanCalculatorPage = lazy(() => import('../features/calculators/LoanCalculatorPage'));
 const MonteCarloPage = lazy(() => import('../features/calculators/MonteCarloPage'));
 const OnboardingPage = lazy(() => import('../features/auth/OnboardingPage'));
+const PostLoginPage = lazy(() => import('../features/auth/PostLoginPage'));
 
 
 function AppRoutes() {
@@ -25,7 +27,15 @@ function AppRoutes() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<HomePage />} />
-          <Route path="onboarding" element={<OnboardingPage />} />
+          <Route path="auth/callback" element={<PostLoginPage />} />
+          <Route
+            path="onboarding"
+            element={
+              <OnboardingRoute>
+                <OnboardingPage />
+              </OnboardingRoute>
+            }
+          />
           <Route
             path="dashboard"
             element={


### PR DESCRIPTION
Add proper routing for new users after OAuth login:
- AuthContext now tracks EasyAuth session and needsOnboarding states
- PostLoginPage (/auth/callback) routes users to onboarding or dashboard
- ProtectedRoute redirects to /onboarding when user needs setup
- OnboardingRoute guards onboarding page access
- Update all login redirects to use /auth/callback