### PR TITLE
Add demo user login without OAuth

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -6,9 +6,12 @@
  *
  * Azure EasyAuth validates the token BEFORE it reaches our code.
  * We only decode the payload - no signature validation needed.
+ *
+ * Demo tokens (iss: finans-demo) are validated with HMAC signature.
  */
 
 import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import { logger } from '../utils/logger';
 
 interface JwtPayload {
@@ -16,7 +19,10 @@ interface JwtPayload {
   email?: string;
   name?: string;
   iss?: string;
+  exp?: number;
 }
+
+const DEMO_SECRET = process.env.DEMO_JWT_SECRET || 'demo-secret-key-for-development';
 
 /**
  * Decode JWT payload without validation.
@@ -35,10 +41,48 @@ function decodeJwtPayload(token: string): JwtPayload | null {
 }
 
 /**
+ * Verify demo token signature and expiration.
+ * Demo tokens use HMAC-SHA256 for signing.
+ */
+function verifyDemoToken(token: string): JwtPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const [headerB64, payloadB64, signature] = parts;
+
+    // Verify signature
+    const expectedSignature = crypto
+      .createHmac('sha256', DEMO_SECRET)
+      .update(`${headerB64}.${payloadB64}`)
+      .digest('base64url');
+
+    if (signature !== expectedSignature) {
+      logger.debug('Demo token signature mismatch');
+      return null;
+    }
+
+    // Decode and parse payload
+    const payload: JwtPayload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8'));
+
+    // Check expiration
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+      logger.debug('Demo token expired');
+      return null;
+    }
+
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Determine provider from JWT issuer
  */
-function getProviderFromIssuer(iss?: string): 'google' | 'facebook' | 'unknown' {
+function getProviderFromIssuer(iss?: string): 'google' | 'facebook' | 'demo' | 'unknown' {
   if (!iss) return 'unknown';
+  if (iss === 'finans-demo') return 'demo';
   if (iss.includes('google')) return 'google';
   if (iss.includes('facebook')) return 'facebook';
   return 'unknown';
@@ -62,14 +106,37 @@ export async function validateAuth(
 
   if (authHeader?.startsWith('Bearer ')) {
     const token = authHeader.slice(7);
-    const payload = decodeJwtPayload(token);
 
-    if (payload?.sub) {
+    // First decode to check the issuer
+    const decodedPayload = decodeJwtPayload(token);
+
+    if (decodedPayload?.iss === 'finans-demo') {
+      // Demo token: verify signature
+      const verifiedPayload = verifyDemoToken(token);
+
+      if (verifiedPayload?.sub) {
+        req.user = {
+          userId: verifiedPayload.sub,
+          email: verifiedPayload.email,
+          name: verifiedPayload.name,
+          provider: 'demo'
+        };
+
+        logger.debug('User authenticated via demo token', {
+          userId: req.user.userId,
+          provider: req.user.provider,
+          path: req.path
+        });
+
+        return next();
+      }
+    } else if (decodedPayload?.sub) {
+      // OAuth token: trust EasyAuth validation
       req.user = {
-        userId: payload.sub,
-        email: payload.email,
-        name: payload.name,
-        provider: getProviderFromIssuer(payload.iss)
+        userId: decodedPayload.sub,
+        email: decodedPayload.email,
+        name: decodedPayload.name,
+        provider: getProviderFromIssuer(decodedPayload.iss)
       };
 
       logger.debug('User authenticated via JWT', {

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,0 +1,303 @@
+/**
+ * Authentication Routes
+ *
+ * Handles demo login for users who want to try the app without OAuth.
+ */
+
+import { Router, Request, Response, IRouter } from 'express';
+import crypto from 'crypto';
+import { logger } from '../utils/logger';
+import { getUserById, createUser } from '../services/userService';
+import { getSnapshotsByUserId, createSnapshot } from '../services/portfolioService';
+import { User } from '../models/User';
+import { MonthlySnapshot } from '../models/Portfolio';
+
+const router: IRouter = Router();
+
+/**
+ * Demo user constants
+ */
+const DEMO_USER_ID = 'demo-user-001';
+const DEMO_SECRET = process.env.DEMO_JWT_SECRET || 'demo-secret-key-for-development';
+
+/**
+ * Create a simple JWT token with HMAC-SHA256 signature.
+ */
+function createDemoToken(): string {
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  };
+
+  const payload = {
+    sub: DEMO_USER_ID,
+    email: 'demo@finans.no',
+    name: 'Demo Bruker',
+    iss: 'finans-demo',
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60, // 24 hours
+  };
+
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+
+  const signature = crypto
+    .createHmac('sha256', DEMO_SECRET)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest('base64url');
+
+  return `${headerB64}.${payloadB64}.${signature}`;
+}
+
+/**
+ * Verify demo token signature
+ */
+export function verifyDemoToken(token: string): { sub: string; email: string; name: string; iss: string } | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const [headerB64, payloadB64, signature] = parts;
+
+    // Verify signature
+    const expectedSignature = crypto
+      .createHmac('sha256', DEMO_SECRET)
+      .update(`${headerB64}.${payloadB64}`)
+      .digest('base64url');
+
+    if (signature !== expectedSignature) {
+      logger.debug('Demo token signature mismatch');
+      return null;
+    }
+
+    // Decode and parse payload
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8'));
+
+    // Check expiration
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+      logger.debug('Demo token expired');
+      return null;
+    }
+
+    // Check issuer
+    if (payload.iss !== 'finans-demo') {
+      logger.debug('Demo token has wrong issuer');
+      return null;
+    }
+
+    return payload;
+  } catch (error) {
+    logger.error('Failed to verify demo token', { error });
+    return null;
+  }
+}
+
+/**
+ * Get or create demo user
+ */
+async function getOrCreateDemoUser(): Promise<User> {
+  let user = await getUserById(DEMO_USER_ID);
+
+  if (!user) {
+    // Create demo user with sample data
+    const demoUser: User = {
+      id: DEMO_USER_ID,
+      nickname: 'Demo Bruker',
+      email: 'demo@finans.no',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      profile: {
+        monthlySalary: 55000,
+        annualExpenses: 400000,
+        birthYear: 1990,
+        plannedRetirementAge: 60,
+        fireNumber: 10000000,
+      },
+      accounts: [
+        {
+          id: 'demo-acc-nordnet',
+          name: 'Nordnet',
+          category: 'sparing',
+          isActive: true,
+          sortOrder: 1,
+          createdAt: new Date(),
+        },
+        {
+          id: 'demo-acc-kron',
+          name: 'Kron',
+          category: 'sparing',
+          isActive: true,
+          sortOrder: 2,
+          createdAt: new Date(),
+        },
+        {
+          id: 'demo-acc-sparekonto',
+          name: 'Sparekonto',
+          category: 'sparing',
+          isActive: true,
+          sortOrder: 3,
+          createdAt: new Date(),
+        },
+        {
+          id: 'demo-acc-huslan',
+          name: 'Boliglån',
+          category: 'gjeld',
+          isActive: true,
+          sortOrder: 1,
+          createdAt: new Date(),
+          loanDetails: {
+            interestRate: 5.0,
+            remainingYears: 25,
+            originalAmount: 3000000,
+          },
+        },
+        {
+          id: 'demo-acc-arbeidsgiver',
+          name: 'Arbeidsgiver',
+          category: 'pensjon',
+          isActive: true,
+          sortOrder: 1,
+          createdAt: new Date(),
+        },
+        {
+          id: 'demo-acc-folketrygden',
+          name: 'Folketrygden',
+          category: 'pensjon',
+          isActive: true,
+          sortOrder: 2,
+          createdAt: new Date(),
+        },
+      ],
+    };
+
+    user = await createUser(demoUser);
+    logger.info('Demo user created', { userId: DEMO_USER_ID });
+  }
+
+  return user;
+}
+
+/**
+ * Generate demo snapshots with realistic portfolio data
+ */
+function generateDemoSnapshots(): Omit<MonthlySnapshot, 'createdAt' | 'updatedAt'>[] {
+  const snapshots: Omit<MonthlySnapshot, 'createdAt' | 'updatedAt'>[] = [];
+
+  // Generate 12 months of data (Dec 2024 to Nov 2025)
+  const baseValues = {
+    nordnet: 280000,
+    kron: 520000,
+    sparekonto: 95000,
+    huslan: -2400000,
+    arbeidsgiver: 450000,
+    folketrygden: 380000,
+  };
+
+  for (let i = 0; i < 12; i++) {
+    const date = new Date(2024, 11 + i, 1); // Start from Dec 2024
+    const dateStr = `01.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+    const monthId = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+    // Simulate growth with some variance
+    const growthFactor = 1 + (0.005 + Math.random() * 0.015); // 0.5-2% monthly growth
+    const nordnetValue = Math.round(baseValues.nordnet * Math.pow(growthFactor, i) + (Math.random() - 0.5) * 10000);
+    const kronValue = Math.round(baseValues.kron * Math.pow(growthFactor, i) + (Math.random() - 0.5) * 15000);
+    const sparekontoValue = Math.round(baseValues.sparekonto + i * 2000 + (Math.random() - 0.5) * 3000);
+    const huslanValue = Math.round(baseValues.huslan + i * 4000); // Paying down debt
+    const arbeidsgiverValue = Math.round(baseValues.arbeidsgiver * Math.pow(1.005, i) + i * 3000);
+    const folketrygdenValue = Math.round(baseValues.folketrygden + i * 1500);
+
+    const sparingSum = nordnetValue + kronValue + sparekontoValue;
+    const gjeldSum = huslanValue;
+    const pensjonSum = arbeidsgiverValue + folketrygdenValue;
+    const totalNetWorth = sparingSum + gjeldSum + pensjonSum;
+
+    snapshots.push({
+      id: `demo-snap-${monthId}`,
+      userId: DEMO_USER_ID,
+      date: dateStr,
+      accounts: [
+        { id: 'demo-acc-nordnet', name: 'Nordnet', assetClass: 'aksjer', value: nordnetValue },
+        { id: 'demo-acc-kron', name: 'Kron', assetClass: 'fond', value: kronValue },
+        { id: 'demo-acc-sparekonto', name: 'Sparekonto', assetClass: 'bankkonto', value: sparekontoValue },
+        { id: 'demo-acc-huslan', name: 'Boliglån', assetClass: 'gjeld', value: huslanValue },
+        { id: 'demo-acc-arbeidsgiver', name: 'Arbeidsgiver', assetClass: 'pensjon', value: arbeidsgiverValue },
+        { id: 'demo-acc-folketrygden', name: 'Folketrygden', assetClass: 'pensjon', value: folketrygdenValue },
+      ],
+      totalNetWorth,
+    });
+  }
+
+  return snapshots;
+}
+
+/**
+ * Seed demo snapshots if they don't exist
+ */
+async function seedDemoSnapshots(): Promise<void> {
+  const existingSnapshots = await getSnapshotsByUserId(DEMO_USER_ID);
+
+  if (existingSnapshots.length > 0) {
+    logger.debug('Demo snapshots already exist', { count: existingSnapshots.length });
+    return;
+  }
+
+  const demoSnapshots = generateDemoSnapshots();
+  const now = new Date();
+
+  for (const snapshot of demoSnapshots) {
+    await createSnapshot({
+      ...snapshot,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  logger.info('Demo snapshots seeded', { count: demoSnapshots.length });
+}
+
+/**
+ * Demo login endpoint
+ *
+ * POST /api/v1/auth/demo-login
+ *
+ * Creates a demo session without OAuth.
+ * Returns a JWT token that can be used for API requests.
+ */
+router.post('/demo-login', async (_req: Request, res: Response) => {
+  try {
+    logger.info('Demo login requested');
+
+    // Get or create demo user and seed snapshots
+    const user = await getOrCreateDemoUser();
+    await seedDemoSnapshots();
+
+    // Generate demo token
+    const token = createDemoToken();
+
+    logger.info('Demo login successful', { userId: DEMO_USER_ID });
+
+    res.status(200).json({
+      data: {
+        token,
+        user: {
+          id: user.id,
+          nickname: user.nickname,
+          email: user.email,
+        },
+      },
+      success: true,
+    });
+  } catch (error) {
+    logger.error('Demo login failed', { error });
+    res.status(500).json({
+      error: {
+        message: 'Demo login failed',
+        code: 'DEMO_LOGIN_FAILED',
+      },
+      success: false,
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import snapshotRoutes from './snapshotRoutes';
 import calculatorRoutes from './calculatorRoutes';
 import summaryRoutes from './summaryRoutes';
 import devRoutes from './devRoutes';
+import authRoutes from './authRoutes';
 
 /**
  * Main route aggregator
@@ -53,6 +54,7 @@ router.get('/test/me', validateAuth, (req: Request, res: Response) => {
 });
 
 // Public route modules (no authentication required)
+router.use('/auth', authRoutes);
 router.use('/calculators', calculatorRoutes);
 
 // Protected route modules (require authentication)

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -16,8 +16,8 @@ declare namespace Express {
       email?: string;
       /** User display name */
       name?: string;
-      /** OAuth provider used for authentication */
-      provider: 'google' | 'facebook' | 'unknown';
+      /** Authentication provider (OAuth or demo) */
+      provider: 'google' | 'facebook' | 'demo' | 'unknown';
     };
   }
 }

--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import client from '../../shared/api/client';
-import { clearAuthToken, getAuthData } from '../../shared/api/authToken';
+import { clearAuthToken, getAuthData, setDemoToken, getDemoToken } from '../../shared/api/authToken';
 import type { User, AuthContextType } from './types';
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -19,14 +19,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const fetchUser = useCallback(async () => {
     try {
-      // First check if we have an EasyAuth session
+      // First check if we have an auth session (demo or EasyAuth)
       let hasSession = false;
       if (isDevelopment) {
         // In development, always assume session exists (backend will inject dev user)
         hasSession = true;
       } else {
-        const authData = await getAuthData();
-        hasSession = authData !== null;
+        // Check for demo token first, then EasyAuth
+        const demoToken = getDemoToken();
+        if (demoToken) {
+          hasSession = true;
+        } else {
+          const authData = await getAuthData();
+          hasSession = authData !== null;
+        }
       }
       setHasEasyAuthSession(hasSession);
 
@@ -88,6 +94,27 @@ export function AuthProvider({ children }: AuthProviderProps) {
     window.location.href = `/.auth/login/${provider}?post_login_redirect_uri=${encodeURIComponent(returnUrl)}`;
   };
 
+  const demoLogin = async () => {
+    try {
+      // Call demo-login endpoint
+      const response = await client.post('/auth/demo-login');
+
+      if (response.data.success && response.data.data?.token) {
+        // Store the demo token
+        setDemoToken(response.data.data.token);
+
+        // Fetch user data with the new token
+        await fetchUser();
+
+        // Redirect to dashboard
+        window.location.href = '/dashboard';
+      }
+    } catch (error) {
+      console.error('Demo login failed:', error);
+      throw error;
+    }
+  };
+
   const logout = () => {
     // Clear cached auth token
     clearAuthToken();
@@ -109,6 +136,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     hasEasyAuthSession,
     needsOnboarding,
     login,
+    demoLogin,
     logout,
     refreshUser,
   };

--- a/frontend/src/features/auth/LoginModal.css
+++ b/frontend/src/features/auth/LoginModal.css
@@ -129,6 +129,50 @@
   background-color: #166FE5;
 }
 
+.login-modal__divider {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.5rem 0;
+}
+
+.login-modal__divider::before,
+.login-modal__divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background-color: var(--border, rgba(44, 44, 44, 0.15));
+}
+
+.login-modal__divider span {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.8125rem;
+  color: var(--text-secondary, #6B6B6B);
+  text-transform: lowercase;
+}
+
+.login-modal__btn--demo {
+  background-color: var(--muted-sage, #8B9A7D);
+  color: white;
+  border: none;
+}
+
+.login-modal__btn--demo:hover:not(:disabled) {
+  background-color: #7A8A6D;
+}
+
+.login-modal__btn--demo:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.login-modal__error {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.8125rem;
+  color: var(--negative, #9D6B5A);
+  margin: 0.5rem 0 0 0;
+}
+
 .login-modal__terms {
   font-family: 'DM Sans', sans-serif;
   font-size: 0.75rem;

--- a/frontend/src/features/auth/LoginModal.tsx
+++ b/frontend/src/features/auth/LoginModal.tsx
@@ -1,11 +1,12 @@
 /**
  * LoginModal Component
  *
- * Modal dialog with Google/Facebook OAuth login buttons.
+ * Modal dialog with Google/Facebook OAuth login buttons and demo mode.
  * Triggered from HomePage for quick login access.
  */
 
-import { useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from './useAuth';
 import './LoginModal.css';
 
 interface LoginModalProps {
@@ -15,6 +16,10 @@ interface LoginModalProps {
 }
 
 export function LoginModal({ isOpen, onClose, returnUrl = '/auth/callback' }: LoginModalProps) {
+  const { demoLogin } = useAuth();
+  const [isDemoLoading, setIsDemoLoading] = useState(false);
+  const [demoError, setDemoError] = useState<string | null>(null);
+
   // Handle escape key to close modal
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -29,6 +34,8 @@ export function LoginModal({ isOpen, onClose, returnUrl = '/auth/callback' }: Lo
     if (isOpen) {
       document.addEventListener('keydown', handleKeyDown);
       document.body.style.overflow = 'hidden';
+      // Reset error on open
+      setDemoError(null);
     }
 
     return () => {
@@ -45,6 +52,18 @@ export function LoginModal({ isOpen, onClose, returnUrl = '/auth/callback' }: Lo
 
   const handleFacebookLogin = () => {
     window.location.href = `/.auth/login/facebook?post_login_redirect_uri=${encodeURIComponent(returnUrl)}`;
+  };
+
+  const handleDemoLogin = async () => {
+    setIsDemoLoading(true);
+    setDemoError(null);
+    try {
+      await demoLogin();
+      // demoLogin redirects on success, so we don't need to do anything here
+    } catch {
+      setDemoError('Demo-innlogging feilet. Prøv igjen.');
+      setIsDemoLoading(false);
+    }
   };
 
   const handleBackdropClick = (e: React.MouseEvent) => {
@@ -113,6 +132,29 @@ export function LoginModal({ isOpen, onClose, returnUrl = '/auth/callback' }: Lo
               </svg>
               <span>Fortsett med Facebook</span>
             </button>
+
+            <div className="login-modal__divider">
+              <span>eller</span>
+            </div>
+
+            <button
+              type="button"
+              className="login-modal__btn login-modal__btn--demo"
+              onClick={handleDemoLogin}
+              disabled={isDemoLoading}
+            >
+              <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"
+                />
+              </svg>
+              <span>{isDemoLoading ? 'Laster...' : 'Prøv demo'}</span>
+            </button>
+
+            {demoError && (
+              <p className="login-modal__error">{demoError}</p>
+            )}
           </div>
 
           <p className="login-modal__terms">

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -40,6 +40,7 @@ export interface AuthContextType {
   hasEasyAuthSession: boolean;
   needsOnboarding: boolean;
   login: (provider: 'google' | 'facebook', returnUrl?: string) => void;
+  demoLogin: () => Promise<void>;
   logout: () => void;
   refreshUser: () => Promise<void>;
 }

--- a/frontend/src/shared/api/authToken.ts
+++ b/frontend/src/shared/api/authToken.ts
@@ -1,8 +1,11 @@
 /**
- * EasyAuth Token Service
+ * Auth Token Service
  *
- * Fetches and caches the access token from Azure EasyAuth.
- * Used to forward authentication to the backend API.
+ * Supports two authentication modes:
+ * 1. Demo tokens - stored in localStorage, validated by backend
+ * 2. EasyAuth tokens - fetched from Azure EasyAuth /.auth/me
+ *
+ * Priority: Demo token (if present) > EasyAuth token
  *
  * EasyAuth /.auth/me returns an array format:
  * [{
@@ -14,6 +17,8 @@
  *   user_id: string
  * }]
  */
+
+const DEMO_TOKEN_KEY = 'finans_demo_token';
 
 interface EasyAuthClaim {
   typ: string;
@@ -50,10 +55,23 @@ let cachedAuthData: CachedAuthData | null = null;
 let tokenFetchPromise: Promise<CachedAuthData | null> | null = null;
 
 /**
- * Returns cached auth data if valid, otherwise fetches fresh data from EasyAuth.
- * Contains both the OAuth access_token and the client principal for the backend.
+ * Returns auth data, checking demo token first, then EasyAuth.
+ * Demo tokens are stored in localStorage and take priority.
  */
 export async function getAuthData(): Promise<CachedAuthData | null> {
+  // Check for demo token first
+  const demoToken = localStorage.getItem(DEMO_TOKEN_KEY);
+  if (demoToken) {
+    // Demo tokens have 24h expiry, set in localStorage
+    // We trust the backend to validate expiry
+    return {
+      idToken: demoToken,
+      accessToken: demoToken,
+      clientPrincipal: '',
+      expiry: new Date(Date.now() + 24 * 60 * 60 * 1000), // Assume valid for 24h
+    };
+  }
+
   // Return cached data if available and not expired
   if (cachedAuthData && new Date() < cachedAuthData.expiry) {
     return cachedAuthData;
@@ -190,11 +208,12 @@ async function fetchAuthToken(): Promise<CachedAuthData | null> {
 }
 
 /**
- * Clears the cached auth data. Call this on logout.
+ * Clears the cached auth data and demo token. Call this on logout.
  */
 export function clearAuthToken(): void {
   cachedAuthData = null;
   tokenFetchPromise = null;
+  localStorage.removeItem(DEMO_TOKEN_KEY);
 }
 
 /**
@@ -203,6 +222,30 @@ export function clearAuthToken(): void {
 export async function refreshAuthToken(): Promise<CachedAuthData | null> {
   clearAuthToken();
   return getAuthData();
+}
+
+/**
+ * Store demo token in localStorage
+ */
+export function setDemoToken(token: string): void {
+  localStorage.setItem(DEMO_TOKEN_KEY, token);
+  // Clear cached EasyAuth data so demo token takes priority
+  cachedAuthData = null;
+  tokenFetchPromise = null;
+}
+
+/**
+ * Get demo token from localStorage
+ */
+export function getDemoToken(): string | null {
+  return localStorage.getItem(DEMO_TOKEN_KEY);
+}
+
+/**
+ * Check if user has a demo session
+ */
+export function isDemoSession(): boolean {
+  return getDemoToken() !== null;
 }
 
 /**


### PR DESCRIPTION
Implement a demo login feature that allows users to try the app without registering via Google/Facebook OAuth:

Backend:
- Add POST /api/v1/auth/demo-login endpoint that generates JWT token
- Create demo user with sample accounts on first login
- Seed 12 months of demo portfolio snapshots
- Update auth middleware to validate demo tokens (HMAC-SHA256)
- Add 'demo' provider type to Express user types

Frontend:
- Update authToken.ts to support demo tokens in localStorage
- Add demoLogin function to AuthContext
- Add "Prøv demo" button to LoginModal with divider
- Style demo button with muted-sage color scheme

Demo user gets:
- 6 accounts (Nordnet, Kron, Sparekonto, Boliglån, pensions)
- 12 months of realistic portfolio data
- 24-hour session expiry