### PR TITLE
Fix login broken by recent commit

### DIFF
--- a/frontend/src/shared/api/authToken.ts
+++ b/frontend/src/shared/api/authToken.ts
@@ -55,6 +55,29 @@ let cachedAuthData: CachedAuthData | null = null;
 let tokenFetchPromise: Promise<CachedAuthData | null> | null = null;
 
 /**
+ * Decode JWT payload without validation (for reading expiry).
+ */
+function decodeJwtPayload(token: string): { exp?: number } | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = atob(parts[1].replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if demo token is expired.
+ */
+function isDemoTokenExpired(token: string): boolean {
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return true; // No expiry = treat as expired
+  return payload.exp < Math.floor(Date.now() / 1000);
+}
+
+/**
  * Returns auth data, checking demo token first, then EasyAuth.
  * Demo tokens are stored in localStorage and take priority.
  */
@@ -62,14 +85,24 @@ export async function getAuthData(): Promise<CachedAuthData | null> {
   // Check for demo token first
   const demoToken = localStorage.getItem(DEMO_TOKEN_KEY);
   if (demoToken) {
-    // Demo tokens have 24h expiry, set in localStorage
-    // We trust the backend to validate expiry
-    return {
-      idToken: demoToken,
-      accessToken: demoToken,
-      clientPrincipal: '',
-      expiry: new Date(Date.now() + 24 * 60 * 60 * 1000), // Assume valid for 24h
-    };
+    // Validate demo token expiry before using
+    if (isDemoTokenExpired(demoToken)) {
+      console.debug('Demo token expired, clearing');
+      localStorage.removeItem(DEMO_TOKEN_KEY);
+      // Fall through to EasyAuth check
+    } else {
+      const payload = decodeJwtPayload(demoToken);
+      const expiry = payload?.exp
+        ? new Date(payload.exp * 1000)
+        : new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      return {
+        idToken: demoToken,
+        accessToken: demoToken,
+        clientPrincipal: '',
+        expiry,
+      };
+    }
   }
 
   // Return cached data if available and not expired
@@ -242,10 +275,12 @@ export function getDemoToken(): string | null {
 }
 
 /**
- * Check if user has a demo session
+ * Check if user has a valid (non-expired) demo session
  */
 export function isDemoSession(): boolean {
-  return getDemoToken() !== null;
+  const token = getDemoToken();
+  if (!token) return false;
+  return !isDemoTokenExpired(token);
 }
 
 /**

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError } from 'axios';
-import { getAccessToken, getClientPrincipal } from './authToken';
+import { getAccessToken, getClientPrincipal, isDemoSession } from './authToken';
 
 /**
  * Axios client with error handling interceptors
@@ -83,24 +83,31 @@ function getErrorMessage(error: AxiosError<ApiErrorResponse>): string {
 // Request interceptor - add auth headers
 client.interceptors.request.use(
   async (config) => {
-    // In production, fetch and forward the EasyAuth tokens
-    if (!isDevelopment) {
+    // Attach auth token in two cases:
+    // 1. Demo session (works in both dev and prod)
+    // 2. Production mode (EasyAuth tokens)
+    // In dev mode without demo session, backend injects dev user
+    const hasDemoSession = isDemoSession();
+    if (hasDemoSession || !isDevelopment) {
       const accessToken = await getAccessToken();
       if (accessToken) {
-        // Send the OAuth id_token as Bearer token
         config.headers['Authorization'] = `Bearer ${accessToken}`;
-        console.debug('Auth: Bearer token attached', {
+        console.debug('Auth: Token attached', {
+          type: hasDemoSession ? 'demo' : 'oauth',
           tokenPrefix: accessToken.substring(0, 20) + '...',
           url: config.url
         });
-      } else {
+      } else if (!isDevelopment) {
+        // Only warn in production (dev mode without demo is expected)
         console.warn('Auth: No access token available for request', { url: config.url });
       }
 
-      // Also send client principal for backward compatibility
-      const clientPrincipal = await getClientPrincipal();
-      if (clientPrincipal) {
-        config.headers['X-MS-CLIENT-PRINCIPAL'] = clientPrincipal;
+      // Also send client principal for backward compatibility (EasyAuth only)
+      if (!hasDemoSession) {
+        const clientPrincipal = await getClientPrincipal();
+        if (clientPrincipal) {
+          config.headers['X-MS-CLIENT-PRINCIPAL'] = clientPrincipal;
+        }
       }
     }
     return config;


### PR DESCRIPTION
Two bugs fixed:

1. Demo token not attached in development mode
   - client.ts only attached tokens in production (!isDevelopment)
   - Demo tokens now attached regardless of environment

2. Expired demo tokens blocking OAuth login
   - Demo tokens took priority over EasyAuth without expiry validation
   - Frontend assumed 24h validity but backend validated actual expiry
   - Now validates demo token expiry before using, clears if expired
   - Falls through to EasyAuth if demo token is expired